### PR TITLE
chore: ignore MEMORY.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ node_modules/
 AGENTS.md
 HEARTBEAT.md
 IDENTITY.md
+MEMORY.md
 SOUL.md
 TOOLS.md
 USER.md
-


### PR DESCRIPTION
## Summary

Add `MEMORY.md` to the repository ignore list so the long-term memory file is not tracked.

## Changes

- added `MEMORY.md` to the root `.gitignore`

## Testing

- verified the change is limited to `.gitignore`
- no build/test run needed for this config-only change

Closes #6