### PR TITLE
feat: migrate family tree storage to MongoDB

### DIFF
--- a/app/api/family-tree/migrate/route.ts
+++ b/app/api/family-tree/migrate/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from "next/server";
+
+import { HttpError, serializeError } from "@/lib/auth";
+import {
+  normalizeFamilyTreeSnapshot,
+  requireAuthenticatedUser,
+  toFamilyTreeResponse,
+  upsertPrimaryFamilyTree,
+} from "@/lib/family-tree/server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: Request) {
+  try {
+    const auth = await requireAuthenticatedUser(request);
+    const body = await request.json().catch(() => {
+      throw new HttpError(400, "Invalid JSON body");
+    });
+    const snapshot = normalizeFamilyTreeSnapshot(body?.data ?? body);
+    const familyTree = await upsertPrimaryFamilyTree({ userId: auth.userId, snapshot });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        migrated: true,
+        familyTree: toFamilyTreeResponse(familyTree),
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    const serialized = serializeError(error);
+    return NextResponse.json(serialized.body, { status: serialized.status });
+  }
+}

--- a/app/api/family-tree/route.ts
+++ b/app/api/family-tree/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { HttpError, serializeError } from "@/lib/auth";
+import {
+  getPrimaryFamilyTree,
+  normalizeFamilyTreeSnapshot,
+  requireAuthenticatedUser,
+  toFamilyTreeResponse,
+  upsertPrimaryFamilyTree,
+} from "@/lib/family-tree/server";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  try {
+    const auth = await requireAuthenticatedUser(request);
+    const familyTree = await getPrimaryFamilyTree(auth.userId);
+
+    return NextResponse.json({ ok: true, familyTree: toFamilyTreeResponse(familyTree) }, { status: 200 });
+  } catch (error) {
+    const serialized = serializeError(error);
+    return NextResponse.json(serialized.body, { status: serialized.status });
+  }
+}
+
+export async function PUT(request: Request) {
+  try {
+    const auth = await requireAuthenticatedUser(request);
+    const body = await request.json().catch(() => {
+      throw new HttpError(400, "Invalid JSON body");
+    });
+    const snapshot = normalizeFamilyTreeSnapshot(body?.data ?? body);
+    const familyTree = await upsertPrimaryFamilyTree({ userId: auth.userId, snapshot });
+
+    return NextResponse.json({ ok: true, familyTree: toFamilyTreeResponse(familyTree) }, { status: 200 });
+  } catch (error) {
+    const serialized = serializeError(error);
+    return NextResponse.json(serialized.body, { status: serialized.status });
+  }
+}

--- a/components/family-tree/family-tree-app.tsx
+++ b/components/family-tree/family-tree-app.tsx
@@ -1,8 +1,20 @@
 "use client";
 
-import { useReducer, useEffect, useState, useCallback } from "react";
-import { loadDatabase, type Database } from "@/lib/family-tree/database";
-import { familyTreeReducer, type Action, type AppState } from "@/lib/family-tree/reducer";
+import { useReducer, useEffect, useState, useCallback, useRef } from "react";
+import {
+  loadDatabase,
+  markFamilyTreeMigrationDone,
+  hasMeaningfulFamilyTreeData,
+  isFamilyTreeMigrationMarkedDone,
+  replaceLocalDatabase,
+} from "@/lib/family-tree/database";
+import {
+  fetchCurrentUser,
+  fetchServerFamilyTree,
+  migrateFamilyTreeToServer,
+  saveServerFamilyTree,
+} from "@/lib/family-tree/client";
+import { familyTreeReducer, type AppState } from "@/lib/family-tree/reducer";
 import { TreeCanvas } from "./tree-canvas";
 import { AddPersonDialog } from "./add-person-dialog";
 import { PersonForm } from "./person-form";
@@ -16,15 +28,79 @@ export function FamilyTreeApp() {
   const [state, dispatch] = useReducer(familyTreeReducer, EMPTY_STATE);
   const [mounted, setMounted] = useState(false);
   const [showInitDialog, setShowInitDialog] = useState(false);
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const skipNextServerSyncRef = useRef(false);
 
   const { db, ui } = state;
 
-  // Load from localStorage on mount
   useEffect(() => {
-    const stored = loadDatabase();
-    dispatch({ type: "INIT", db: stored });
-    setMounted(true);
+    let cancelled = false;
+
+    async function initialize() {
+      const localDb = loadDatabase();
+      const auth = await fetchCurrentUser();
+
+      if (cancelled) {
+        return;
+      }
+
+      if (!auth?.userId) {
+        dispatch({ type: "INIT", db: localDb });
+        setIsAuthenticated(false);
+        setMounted(true);
+        return;
+      }
+
+      setIsAuthenticated(true);
+
+      const serverDb = await fetchServerFamilyTree();
+      if (cancelled) {
+        return;
+      }
+
+      if (hasMeaningfulFamilyTreeData(localDb) && !isFamilyTreeMigrationMarkedDone()) {
+        const migration = await migrateFamilyTreeToServer(localDb);
+        if (cancelled) {
+          return;
+        }
+
+        markFamilyTreeMigrationDone();
+        const nextDb = migration.familyTree ?? localDb;
+        replaceLocalDatabase(nextDb);
+        skipNextServerSyncRef.current = true;
+        dispatch({ type: "INIT", db: nextDb });
+        setMounted(true);
+        return;
+      }
+
+      const nextDb = serverDb ?? localDb;
+      replaceLocalDatabase(nextDb);
+      skipNextServerSyncRef.current = true;
+      dispatch({ type: "INIT", db: nextDb });
+      setMounted(true);
+    }
+
+    void initialize();
+
+    return () => {
+      cancelled = true;
+    };
   }, []);
+
+  useEffect(() => {
+    if (!mounted || !isAuthenticated) {
+      return;
+    }
+
+    if (skipNextServerSyncRef.current) {
+      skipNextServerSyncRef.current = false;
+      return;
+    }
+
+    void saveServerFamilyTree(db).catch(() => {
+      // Keep local state intact if server sync fails.
+    });
+  }, [db, mounted, isAuthenticated]);
 
   const handleAddRoot = useCallback(
     (name: string, gender: "male" | "female") => {
@@ -33,13 +109,6 @@ export function FamilyTreeApp() {
     },
     []
   );
-
-  const handleClearTree = useCallback(() => {
-    if (typeof window !== "undefined") {
-      localStorage.removeItem("family-tree-db");
-    }
-    dispatch({ type: "INIT", db: { persons: [], relationships: [] } });
-  }, []);
 
   const handlePersonFormSubmit = useCallback(
     (
@@ -66,7 +135,6 @@ export function FamilyTreeApp() {
 
   const isEmpty = db.persons.length === 0;
 
-  // If the form is open and we're on the empty state (just added root), show form
   const editingPerson =
     ui.isFormOpen && ui.editingPersonId
       ? db.persons.find((p) => p.id === ui.editingPersonId) ?? null
@@ -81,21 +149,7 @@ export function FamilyTreeApp() {
           </svg>
           <h1>Phả hệ</h1>
         </div>
-        <div className="header-actions">
-          {!isEmpty && (
-            <>
-              {/* <button
-                className="header-btn"
-                onClick={() => setShowInitDialog(true)}
-              >
-                Add Root
-              </button> */}
-              {/* <button className="header-btn danger" onClick={handleClearTree}>
-                Clear All
-              </button> */}
-            </>
-          )}
-        </div>
+        <div className="header-actions" />
       </header>
 
       <main className="family-tree-main">
@@ -108,10 +162,7 @@ export function FamilyTreeApp() {
             </div>
             <h2>Start Your Family Tree</h2>
             <p>Add the first person to begin building your family tree.</p>
-            <button
-              className="btn-add-root"
-              onClick={() => setShowInitDialog(true)}
-            >
+            <button className="btn-add-root" onClick={() => setShowInitDialog(true)}>
               Add First Person
             </button>
           </div>
@@ -134,7 +185,6 @@ export function FamilyTreeApp() {
         />
       )}
 
-      {/* Show person form at app level if tree is empty (root just added) */}
       {isEmpty && ui.isFormOpen && editingPerson && (
         <PersonForm
           person={editingPerson}

--- a/lib/family-tree/client.ts
+++ b/lib/family-tree/client.ts
@@ -1,0 +1,94 @@
+import type { Database } from "@/lib/family-tree/database";
+
+export interface AuthMeResponse {
+  ok: boolean;
+  userId?: string | null;
+  user?: {
+    id?: string | null;
+    email?: string | null;
+    name?: string | null;
+  } | null;
+}
+
+export interface FamilyTreeApiResponse {
+  ok: boolean;
+  familyTree: {
+    id: string | null;
+    name: string;
+    description: string | null;
+    data: Database;
+    rootPersonId: string | null;
+    createdAt: string | Date;
+    updatedAt: string | Date;
+  } | null;
+}
+
+export async function fetchCurrentUser() {
+  const response = await fetch("/api/auth/me", {
+    method: "GET",
+    credentials: "include",
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const data = (await response.json()) as AuthMeResponse;
+  if (!data.ok || !data.userId) {
+    return null;
+  }
+
+  return data;
+}
+
+export async function fetchServerFamilyTree(): Promise<Database | null> {
+  const response = await fetch("/api/family-tree", {
+    method: "GET",
+    credentials: "include",
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = (await response.json()) as FamilyTreeApiResponse;
+  return payload.familyTree?.data ?? null;
+}
+
+export async function saveServerFamilyTree(data: Database): Promise<void> {
+  const response = await fetch("/api/family-tree", {
+    method: "PUT",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ data }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to save family tree");
+  }
+}
+
+export async function migrateFamilyTreeToServer(data: Database): Promise<{ migrated: boolean; familyTree: Database | null }> {
+  const response = await fetch("/api/family-tree/migrate", {
+    method: "POST",
+    credentials: "include",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ data }),
+  });
+
+  if (!response.ok) {
+    throw new Error("Failed to migrate family tree");
+  }
+
+  const payload = (await response.json()) as FamilyTreeApiResponse & { migrated: boolean };
+  return {
+    migrated: payload.migrated,
+    familyTree: payload.familyTree?.data ?? null,
+  };
+}

--- a/lib/family-tree/database.ts
+++ b/lib/family-tree/database.ts
@@ -27,6 +27,53 @@ export interface Database {
 }
 
 const STORAGE_KEY = "family-tree-db";
+export const FAMILY_TREE_MIGRATION_FLAG_KEY = "family-tree-migrated-to-server";
+
+export function getFamilyTreeStorageKey(): string {
+  return STORAGE_KEY;
+}
+
+export function getFamilyTreeMigrationFlagKey(): string {
+  return FAMILY_TREE_MIGRATION_FLAG_KEY;
+}
+
+export function hasLocalFamilyTreeData(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return Boolean(localStorage.getItem(STORAGE_KEY));
+}
+
+export function isFamilyTreeMigrationMarkedDone(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return localStorage.getItem(FAMILY_TREE_MIGRATION_FLAG_KEY) === "true";
+}
+
+export function markFamilyTreeMigrationDone(): void {
+  if (typeof window === "undefined") return;
+  localStorage.setItem(FAMILY_TREE_MIGRATION_FLAG_KEY, "true");
+}
+
+export function clearFamilyTreeMigrationFlag(): void {
+  if (typeof window === "undefined") return;
+  localStorage.removeItem(FAMILY_TREE_MIGRATION_FLAG_KEY);
+}
+
+export function hasMeaningfulFamilyTreeData(db: Database): boolean {
+  return db.persons.length > 0 || db.relationships.length > 0;
+}
+
+export function getLocalDatabaseSnapshot(): Database {
+  return loadDatabase();
+}
+
+export function replaceLocalDatabase(db: Database): void {
+  saveDatabase(db);
+}
 
 function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;

--- a/lib/family-tree/server.ts
+++ b/lib/family-tree/server.ts
@@ -1,0 +1,183 @@
+import { ObjectId, type Collection, type Db } from "mongodb";
+import { z } from "zod";
+
+import { getAuthenticatedUserFromRequest, getAuthDb, HttpError } from "@/lib/auth";
+import {
+  COLLECTIONS,
+  createFamilyTreeDocument,
+  type CollectionSchemaMap,
+  type FamilyTreeDataSnapshot,
+  type FamilyTreeDocument,
+  type FamilyTreePersonSnapshot,
+  type FamilyTreeRelationshipSnapshot,
+} from "@/lib/db/schemas";
+
+const DEFAULT_TREE_NAME = "My Family Tree";
+const DEFAULT_TREE_DESCRIPTION = "Primary family tree";
+
+const personSchema = z.object({
+  id: z.string().min(1),
+  name: z.string(),
+  gender: z.enum(["male", "female"]),
+  birthYear: z.number().int().nullable(),
+  nickname: z.string().nullable(),
+  phone: z.string().nullable(),
+  address: z.string().nullable(),
+  isDeceased: z.boolean(),
+  createdAt: z.number().int(),
+});
+
+const relationshipSchema = z.object({
+  id: z.string().min(1),
+  type: z.enum(["parent", "spouse"]),
+  person1Id: z.string().min(1),
+  person2Id: z.string().min(1),
+  orderIndex: z.number().int(),
+});
+
+export const familyTreeSnapshotSchema = z.object({
+  persons: z.array(personSchema),
+  relationships: z.array(relationshipSchema),
+});
+
+const ensuredFamilyTreeIndexes = new WeakSet<Db>();
+
+function getCollection(db: Db): Collection<CollectionSchemaMap["familyTrees"]> {
+  return db.collection<CollectionSchemaMap["familyTrees"]>(COLLECTIONS.familyTrees);
+}
+
+export async function ensureFamilyTreeIndexes(db: Db): Promise<void> {
+  if (ensuredFamilyTreeIndexes.has(db)) {
+    return;
+  }
+
+  const collection = getCollection(db);
+  await Promise.all([
+    collection.createIndex({ userId: 1, updatedAt: -1 }, { name: "family_trees_user_updated_desc" }),
+    collection.createIndex({ userId: 1, name: 1 }, { name: "family_trees_user_name_unique", unique: true }),
+  ]);
+
+  ensuredFamilyTreeIndexes.add(db);
+}
+
+export async function getFamilyTreeDb(): Promise<Db> {
+  const db = await getAuthDb();
+  await ensureFamilyTreeIndexes(db);
+  return db;
+}
+
+function getRootPersonId(snapshot: FamilyTreeDataSnapshot): string | null {
+  const childIds = new Set(
+    snapshot.relationships.filter((rel) => rel.type === "parent").map((rel) => rel.person2Id),
+  );
+
+  return snapshot.persons.find((person) => !childIds.has(person.id))?.id ?? snapshot.persons[0]?.id ?? null;
+}
+
+function sanitizePerson(person: z.infer<typeof personSchema>): FamilyTreePersonSnapshot {
+  return {
+    id: person.id,
+    name: person.name,
+    gender: person.gender,
+    birthYear: person.birthYear,
+    nickname: person.nickname,
+    phone: person.phone,
+    address: person.address,
+    isDeceased: person.isDeceased,
+    createdAt: person.createdAt,
+  };
+}
+
+function sanitizeRelationship(relationship: z.infer<typeof relationshipSchema>): FamilyTreeRelationshipSnapshot {
+  return {
+    id: relationship.id,
+    type: relationship.type,
+    person1Id: relationship.person1Id,
+    person2Id: relationship.person2Id,
+    orderIndex: relationship.orderIndex,
+  };
+}
+
+export function normalizeFamilyTreeSnapshot(input: unknown): FamilyTreeDataSnapshot {
+  const parsed = familyTreeSnapshotSchema.parse(input);
+
+  return {
+    persons: parsed.persons.map(sanitizePerson),
+    relationships: parsed.relationships.map(sanitizeRelationship),
+  };
+}
+
+export async function getPrimaryFamilyTree(userId: string): Promise<FamilyTreeDocument | null> {
+  const db = await getFamilyTreeDb();
+  const collection = getCollection(db);
+
+  return collection.findOne({ userId: new ObjectId(userId), name: DEFAULT_TREE_NAME });
+}
+
+export async function upsertPrimaryFamilyTree(params: {
+  userId: string;
+  snapshot: FamilyTreeDataSnapshot;
+}): Promise<FamilyTreeDocument> {
+  if (!ObjectId.isValid(params.userId)) {
+    throw new HttpError(401, "Authentication required");
+  }
+
+  const db = await getFamilyTreeDb();
+  const collection = getCollection(db);
+  const now = new Date();
+  const userObjectId = new ObjectId(params.userId);
+  const rootPersonId = getRootPersonId(params.snapshot);
+  const existing = await collection.findOne({ userId: userObjectId, name: DEFAULT_TREE_NAME });
+
+  if (!existing) {
+    const document = createFamilyTreeDocument({
+      userId: userObjectId,
+      name: DEFAULT_TREE_NAME,
+      description: DEFAULT_TREE_DESCRIPTION,
+      data: params.snapshot,
+      rootPersonId,
+      now,
+    });
+
+    const result = await collection.insertOne(document);
+    return { ...document, _id: result.insertedId };
+  }
+
+  await collection.updateOne(
+    { _id: existing._id },
+    {
+      $set: {
+        data: params.snapshot,
+        rootPersonId,
+        updatedAt: now,
+      },
+    },
+  );
+
+  return {
+    ...existing,
+    data: params.snapshot,
+    rootPersonId,
+    updatedAt: now,
+  };
+}
+
+export async function requireAuthenticatedUser(request: Request) {
+  return getAuthenticatedUserFromRequest(request);
+}
+
+export function toFamilyTreeResponse(document: FamilyTreeDocument | null) {
+  if (!document) {
+    return null;
+  }
+
+  return {
+    id: document._id?.toString() ?? null,
+    name: document.name,
+    description: document.description,
+    data: document.data,
+    rootPersonId: document.rootPersonId,
+    createdAt: document.createdAt,
+    updatedAt: document.updatedAt,
+  };
+}


### PR DESCRIPTION
## Summary
- add authenticated family tree API endpoints backed by MongoDB
- add a client-side migration flow from localStorage to user-scoped server persistence
- sync authenticated family tree changes to the server after initial load

## Changes
- add `GET /api/family-tree` and `PUT /api/family-tree` for loading and saving the authenticated user's primary tree
- add `POST /api/family-tree/migrate` to upload existing localStorage data for the current user
- validate incoming family tree snapshots on the server with Zod before writing to MongoDB
- upsert a single primary family tree per user to keep migration idempotent and avoid duplicate trees
- mark client migration as completed with a localStorage flag after a successful upload
- prefer server data for authenticated users while keeping localStorage as the fallback/deprecation path

## Acceptance Mapping
- existing users can migrate localStorage data after login
- family tree data is stored in MongoDB and linked to `userId`
- repeated migration requests overwrite the same primary tree instead of creating duplicates
- localStorage remains available as fallback, but can now be deprecated

## Validation
- `pnpm build` ✅
- `pnpm lint` ⚠️ fails because `eslint` is not available in the current environment (`sh: 1: eslint: not found`)

Closes #27
