### PR TITLE
feat: add minimal authentication UI

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -1,0 +1,11 @@
+import { AuthShell } from "@/components/auth/auth-shell";
+
+export default function AuthPage() {
+  return (
+    <div className="min-h-screen bg-background px-4 py-10 sm:px-6">
+      <div className="mx-auto flex min-h-[calc(100vh-5rem)] max-w-2xl items-center justify-center">
+        <AuthShell />
+      </div>
+    </div>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,6 +1,18 @@
+import Link from "next/link";
+
 import { FamilyTreeApp } from "@/components/family-tree/family-tree-app";
+import { Button } from "@/components/ui/button";
 import "./family-tree.css";
 
 export default function Page() {
-  return <FamilyTreeApp />;
+  return (
+    <div className="relative">
+      <div className="absolute top-4 right-4 z-20">
+        <Button asChild variant="outline">
+          <Link href="/auth">Auth</Link>
+        </Button>
+      </div>
+      <FamilyTreeApp />
+    </div>
+  );
 }

--- a/components/auth/auth-feedback.tsx
+++ b/components/auth/auth-feedback.tsx
@@ -1,0 +1,25 @@
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
+
+import type { FormState } from "@/components/auth/types";
+
+export function AuthFeedback({ state }: { state: FormState }) {
+  if (!state.error && !state.success) {
+    return null;
+  }
+
+  if (state.error) {
+    return (
+      <Alert variant="destructive">
+        <AlertTitle>Request failed</AlertTitle>
+        <AlertDescription>{state.error}</AlertDescription>
+      </Alert>
+    );
+  }
+
+  return (
+    <Alert>
+      <AlertTitle>Success</AlertTitle>
+      <AlertDescription>{state.success}</AlertDescription>
+    </Alert>
+  );
+}

--- a/components/auth/auth-shell.tsx
+++ b/components/auth/auth-shell.tsx
@@ -1,0 +1,398 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useState } from "react";
+import { ArrowLeft, Link2, LogIn, LogOut, Mail, ShieldCheck, UserPlus } from "lucide-react";
+
+import { AuthFeedback } from "@/components/auth/auth-feedback";
+import { FormField } from "@/components/auth/form-field";
+import { LoginForm } from "@/components/auth/login-form";
+import { RegisterFlow } from "@/components/auth/register-flow";
+import { initialFormState, type FormState } from "@/components/auth/types";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import {
+  fetchCurrentSession,
+  loginWithPassword,
+  logoutCurrentSession,
+  requestOtp,
+  verifyOtpCode,
+  type AuthUser,
+  type OtpPurpose,
+} from "@/lib/auth/client";
+
+const otpPurposeOptions: { value: OtpPurpose; label: string; description: string }[] = [
+  { value: "sign-in", label: "Sign in", description: "Complete a passwordless sign-in flow." },
+  { value: "verify-email", label: "Verify email", description: "Confirm an email address for the current account." },
+  { value: "reset-password", label: "Reset password", description: "Request a verification code for password recovery." },
+  { value: "link-account", label: "Link account", description: "Reserved for future account linking and social auth expansion." },
+];
+
+export function AuthShell() {
+  const [activeTab, setActiveTab] = useState<"login" | "register" | "request-otp" | "verify-otp">("login");
+  const [sessionUser, setSessionUser] = useState<AuthUser | null>(null);
+  const [sessionLoading, setSessionLoading] = useState(true);
+
+  const [loginEmail, setLoginEmail] = useState("");
+  const [loginPassword, setLoginPassword] = useState("");
+  const [loginState, setLoginState] = useState<FormState>(initialFormState);
+
+  const [otpEmail, setOtpEmail] = useState("");
+  const [otpCode, setOtpCode] = useState("");
+  const [otpPurpose, setOtpPurpose] = useState<OtpPurpose>("sign-in");
+  const [requestOtpState, setRequestOtpState] = useState<FormState>(initialFormState);
+  const [verifyOtpState, setVerifyOtpState] = useState<FormState>(initialFormState);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadSession() {
+      const session = await fetchCurrentSession();
+      if (cancelled) return;
+      setSessionUser(session?.user ?? null);
+      setSessionLoading(false);
+    }
+
+    void loadSession();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const selectedPurpose = useMemo(
+    () => otpPurposeOptions.find((option) => option.value === otpPurpose) ?? otpPurposeOptions[0],
+    [otpPurpose],
+  );
+
+  async function refreshSession() {
+    const session = await fetchCurrentSession();
+    setSessionUser(session?.user ?? null);
+    setSessionLoading(false);
+  }
+
+  async function handleLogin(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoginState({ loading: true, error: null, success: null });
+
+    try {
+      const response = await loginWithPassword({
+        email: loginEmail.trim(),
+        password: loginPassword,
+      });
+
+      setSessionUser(response.user ?? null);
+      setLoginState({
+        loading: false,
+        error: null,
+        success: `Logged in as ${response.user?.email ?? loginEmail.trim()}.`,
+      });
+    } catch (error) {
+      setLoginState({
+        loading: false,
+        error: error instanceof Error ? error.message : "Unable to log in.",
+        success: null,
+      });
+    }
+  }
+
+  async function handleLogout() {
+    try {
+      await logoutCurrentSession();
+      setSessionUser(null);
+      setLoginState(initialFormState);
+      setVerifyOtpState(initialFormState);
+      setRequestOtpState(initialFormState);
+    } catch {
+      // keep logout quiet in this minimal shell
+    }
+  }
+
+  async function handleRequestOtp(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setRequestOtpState({ loading: true, error: null, success: null });
+
+    try {
+      const response = await requestOtp({
+        email: otpEmail.trim(),
+        purpose: otpPurpose,
+      });
+
+      setRequestOtpState({
+        loading: false,
+        error: null,
+        success: `OTP requested for ${otpEmail.trim()} (${response.purpose ?? otpPurpose}).`,
+      });
+      setActiveTab("verify-otp");
+      setVerifyOtpState(initialFormState);
+    } catch (error) {
+      setRequestOtpState({
+        loading: false,
+        error: error instanceof Error ? error.message : "Unable to request OTP.",
+        success: null,
+      });
+    }
+  }
+
+  async function handleVerifyOtp(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setVerifyOtpState({ loading: true, error: null, success: null });
+
+    try {
+      const response = await verifyOtpCode({
+        email: otpEmail.trim(),
+        otp: otpCode.trim(),
+        purpose: otpPurpose,
+      });
+
+      if (otpPurpose === "sign-in") {
+        await refreshSession();
+      }
+
+      setVerifyOtpState({
+        loading: false,
+        error: null,
+        success:
+          otpPurpose === "sign-in"
+            ? `OTP verified and signed in as ${response.user?.email ?? otpEmail.trim()}.`
+            : `OTP verified for ${otpEmail.trim()} (${otpPurpose}).`,
+      });
+    } catch (error) {
+      setVerifyOtpState({
+        loading: false,
+        error: error instanceof Error ? error.message : "Unable to verify OTP.",
+        success: null,
+      });
+    }
+  }
+
+  return (
+    <Card className="w-full max-w-2xl">
+      <CardHeader className="space-y-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <Button asChild variant="ghost" className="-ml-3 w-fit px-3 text-muted-foreground">
+              <Link href="/">
+                <ArrowLeft className="size-4" />
+                Back to family tree
+              </Link>
+            </Button>
+            <div>
+              <CardTitle>Authentication</CardTitle>
+              <CardDescription>
+                Minimal auth UI wired to the existing backend APIs, with room for future account linking.
+              </CardDescription>
+            </div>
+          </div>
+        </div>
+
+        <div className="rounded-lg border bg-muted/30 p-4 text-sm">
+          <div className="flex items-center gap-2 font-medium text-foreground">
+            <ShieldCheck className="size-4 text-emerald-600" />
+            Current session
+          </div>
+          {sessionLoading ? (
+            <p className="mt-2 text-muted-foreground">Checking session...</p>
+          ) : sessionUser ? (
+            <div className="mt-3 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div className="space-y-1">
+                <p className="font-medium text-foreground">{sessionUser.email}</p>
+                <p className="text-muted-foreground">
+                  {sessionUser.name ? `${sessionUser.name} • ` : ""}
+                  {sessionUser.emailVerifiedAt ? "Email verified" : "Email not verified yet"}
+                </p>
+              </div>
+              <Button variant="outline" onClick={handleLogout}>
+                <LogOut className="size-4" />
+                Logout
+              </Button>
+            </div>
+          ) : (
+            <p className="mt-2 text-muted-foreground">No active session.</p>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent>
+        <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as typeof activeTab)} className="gap-4">
+          <TabsList className="grid h-auto w-full grid-cols-2 gap-2 bg-transparent p-0 sm:grid-cols-4">
+            <TabsTrigger value="login" className="border">Login</TabsTrigger>
+            <TabsTrigger value="register" className="border">Register</TabsTrigger>
+            <TabsTrigger value="request-otp" className="border">Request OTP</TabsTrigger>
+            <TabsTrigger value="verify-otp" className="border">Verify OTP</TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="login">
+            <div className="rounded-lg border p-4">
+              <div className="mb-4 space-y-1">
+                <h2 className="font-medium">Password login</h2>
+                <p className="text-sm text-muted-foreground">Sign in with email and password via /api/auth/login.</p>
+              </div>
+              <LoginForm
+                email={loginEmail}
+                password={loginPassword}
+                state={loginState}
+                onEmailChange={(value) => {
+                  setLoginEmail(value);
+                  if (!otpEmail) setOtpEmail(value);
+                }}
+                onPasswordChange={setLoginPassword}
+                onSubmit={handleLogin}
+                onSwitchToRegister={() => setActiveTab("register")}
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="register">
+            <div className="rounded-lg border p-4">
+              <div className="mb-4 space-y-1">
+                <h2 className="font-medium">Register with OTP confirmation</h2>
+                <p className="text-sm text-muted-foreground">
+                  Request a sign-up OTP, verify it, create the account, then sign in automatically.
+                </p>
+              </div>
+              <RegisterFlow
+                defaultEmail={loginEmail || otpEmail}
+                onSwitchToLogin={(prefillEmail) => {
+                  if (prefillEmail) {
+                    setLoginEmail(prefillEmail);
+                    setOtpEmail(prefillEmail);
+                  }
+                  setActiveTab("login");
+                }}
+                onRegisteredAndLoggedIn={async () => {
+                  await refreshSession();
+                }}
+              />
+            </div>
+          </TabsContent>
+
+          <TabsContent value="request-otp">
+            <div className="rounded-lg border p-4">
+              <div className="mb-4 space-y-1">
+                <h2 className="font-medium">Request OTP</h2>
+                <p className="text-sm text-muted-foreground">
+                  Trigger /api/auth/request-otp for sign-in, verify-email, reset-password, or future link-account flows.
+                </p>
+              </div>
+              <form className="space-y-4" onSubmit={handleRequestOtp}>
+                <AuthFeedback state={requestOtpState} />
+
+                <FormField label="Email" htmlFor="otp-email">
+                  <Input
+                    id="otp-email"
+                    type="email"
+                    autoComplete="email"
+                    value={otpEmail}
+                    onChange={(event) => setOtpEmail(event.target.value)}
+                    placeholder="you@example.com"
+                    required
+                  />
+                </FormField>
+
+                <FormField label="Purpose" htmlFor="otp-purpose">
+                  <select
+                    id="otp-purpose"
+                    className="flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                    value={otpPurpose}
+                    onChange={(event) => setOtpPurpose(event.target.value as OtpPurpose)}
+                  >
+                    {otpPurposeOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </FormField>
+
+                <div className="rounded-md border bg-muted/30 p-3 text-sm text-muted-foreground">
+                  <div className="flex items-center gap-2 font-medium text-foreground">
+                    <Link2 className="size-4" />
+                    {selectedPurpose.label}
+                  </div>
+                  <p className="mt-1">{selectedPurpose.description}</p>
+                </div>
+
+                <Button className="w-full" type="submit" disabled={requestOtpState.loading}>
+                  <Mail className="size-4" />
+                  {requestOtpState.loading ? "Requesting OTP..." : "Request OTP"}
+                </Button>
+              </form>
+            </div>
+          </TabsContent>
+
+          <TabsContent value="verify-otp">
+            <div className="rounded-lg border p-4">
+              <div className="mb-4 space-y-1">
+                <h2 className="font-medium">Verify OTP</h2>
+                <p className="text-sm text-muted-foreground">
+                  Complete OTP verification via /api/auth/verify-otp. Sign-in purpose will also establish a session.
+                </p>
+              </div>
+              <form className="space-y-4" onSubmit={handleVerifyOtp}>
+                <AuthFeedback state={verifyOtpState} />
+
+                <FormField label="Email" htmlFor="verify-otp-email">
+                  <Input
+                    id="verify-otp-email"
+                    type="email"
+                    autoComplete="email"
+                    value={otpEmail}
+                    onChange={(event) => setOtpEmail(event.target.value)}
+                    placeholder="you@example.com"
+                    required
+                  />
+                </FormField>
+
+                <FormField label="Purpose" htmlFor="verify-otp-purpose">
+                  <select
+                    id="verify-otp-purpose"
+                    className="flex h-9 w-full rounded-md border bg-transparent px-3 py-1 text-sm shadow-xs outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50"
+                    value={otpPurpose}
+                    onChange={(event) => setOtpPurpose(event.target.value as OtpPurpose)}
+                  >
+                    {otpPurposeOptions.map((option) => (
+                      <option key={option.value} value={option.value}>
+                        {option.label}
+                      </option>
+                    ))}
+                  </select>
+                </FormField>
+
+                <FormField label="OTP code" htmlFor="verify-otp-code">
+                  <Input
+                    id="verify-otp-code"
+                    type="text"
+                    inputMode="numeric"
+                    pattern="[0-9]{6}"
+                    value={otpCode}
+                    onChange={(event) => setOtpCode(event.target.value)}
+                    placeholder="6-digit code"
+                    required
+                  />
+                </FormField>
+
+                <Button className="w-full" type="submit" disabled={verifyOtpState.loading}>
+                  <LogIn className="size-4" />
+                  {verifyOtpState.loading ? "Verifying OTP..." : "Verify OTP"}
+                </Button>
+              </form>
+            </div>
+          </TabsContent>
+        </Tabs>
+
+        <div className="mt-6 rounded-lg border border-dashed p-4 text-sm text-muted-foreground">
+          <div className="flex items-center gap-2 font-medium text-foreground">
+            <UserPlus className="size-4" />
+            Ready for expansion
+          </div>
+          <p className="mt-1">
+            The OTP purpose model already includes <code className="rounded bg-muted px-1 py-0.5">link-account</code>, so this UI can grow into account linking or social auth later without changing the family tree flow.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/components/auth/form-field.tsx
+++ b/components/auth/form-field.tsx
@@ -1,0 +1,20 @@
+import type React from "react";
+
+import { Label } from "@/components/ui/label";
+
+export function FormField({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={htmlFor}>{label}</Label>
+      {children}
+    </div>
+  );
+}

--- a/components/auth/login-form.tsx
+++ b/components/auth/login-form.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { LogIn } from "lucide-react";
+
+import { AuthFeedback } from "@/components/auth/auth-feedback";
+import { FormField } from "@/components/auth/form-field";
+import type { FormState } from "@/components/auth/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function LoginForm({
+  email,
+  password,
+  state,
+  onEmailChange,
+  onPasswordChange,
+  onSubmit,
+  onSwitchToRegister,
+}: {
+  email: string;
+  password: string;
+  state: FormState;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  onSwitchToRegister: () => void;
+}) {
+  return (
+    <form className="space-y-4" onSubmit={onSubmit}>
+      <AuthFeedback state={state} />
+
+      <FormField label="Email" htmlFor="login-email">
+        <Input
+          id="login-email"
+          type="email"
+          autoComplete="email"
+          value={email}
+          onChange={(event) => onEmailChange(event.target.value)}
+          placeholder="you@example.com"
+          required
+        />
+      </FormField>
+
+      <FormField label="Password" htmlFor="login-password">
+        <Input
+          id="login-password"
+          type="password"
+          autoComplete="current-password"
+          value={password}
+          onChange={(event) => onPasswordChange(event.target.value)}
+          placeholder="Your password"
+          required
+        />
+      </FormField>
+
+      <Button className="w-full" type="submit" disabled={state.loading}>
+        <LogIn className="size-4" />
+        {state.loading ? "Logging in..." : "Đăng nhập"}
+      </Button>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Chưa có tài khoản?{" "}
+        <button
+          type="button"
+          className="font-medium text-foreground underline underline-offset-4"
+          onClick={onSwitchToRegister}
+        >
+          Đăng ký ngay
+        </button>
+      </p>
+    </form>
+  );
+}

--- a/components/auth/register-details-step.tsx
+++ b/components/auth/register-details-step.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Mail } from "lucide-react";
+
+import { AuthFeedback } from "@/components/auth/auth-feedback";
+import { FormField } from "@/components/auth/form-field";
+import type { FormState } from "@/components/auth/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function RegisterDetailsStep({
+  name,
+  email,
+  password,
+  state,
+  onNameChange,
+  onEmailChange,
+  onPasswordChange,
+  onSubmit,
+  onSwitchToLogin,
+}: {
+  name: string;
+  email: string;
+  password: string;
+  state: FormState;
+  onNameChange: (value: string) => void;
+  onEmailChange: (value: string) => void;
+  onPasswordChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  onSwitchToLogin: () => void;
+}) {
+  return (
+    <form className="space-y-4" onSubmit={onSubmit}>
+      <AuthFeedback state={state} />
+
+      <FormField label="Name (optional)" htmlFor="register-name">
+        <Input
+          id="register-name"
+          type="text"
+          autoComplete="name"
+          value={name}
+          onChange={(event) => onNameChange(event.target.value)}
+          placeholder="Your name"
+        />
+      </FormField>
+
+      <FormField label="Email" htmlFor="register-email">
+        <Input
+          id="register-email"
+          type="email"
+          autoComplete="email"
+          value={email}
+          onChange={(event) => onEmailChange(event.target.value)}
+          placeholder="you@example.com"
+          required
+        />
+      </FormField>
+
+      <FormField label="Password" htmlFor="register-password">
+        <Input
+          id="register-password"
+          type="password"
+          autoComplete="new-password"
+          value={password}
+          onChange={(event) => onPasswordChange(event.target.value)}
+          placeholder="At least 8 characters"
+          minLength={8}
+          required
+        />
+      </FormField>
+
+      <Button className="w-full" type="submit" disabled={state.loading}>
+        <Mail className="size-4" />
+        {state.loading ? "Sending OTP..." : "Tiếp tục"}
+      </Button>
+
+      <p className="text-center text-sm text-muted-foreground">
+        Đã có tài khoản?{" "}
+        <button
+          type="button"
+          className="font-medium text-foreground underline underline-offset-4"
+          onClick={onSwitchToLogin}
+        >
+          Đăng nhập
+        </button>
+      </p>
+    </form>
+  );
+}

--- a/components/auth/register-flow.tsx
+++ b/components/auth/register-flow.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { useState } from "react";
+
+import { RegisterDetailsStep } from "@/components/auth/register-details-step";
+import { RegisterOtpStep } from "@/components/auth/register-otp-step";
+import { initialFormState, type FormState } from "@/components/auth/types";
+import { loginWithPassword, registerWithPassword, requestOtp, verifyOtpCode } from "@/lib/auth/client";
+
+export function RegisterFlow({
+  onRegisteredAndLoggedIn,
+  onSwitchToLogin,
+  defaultName = "",
+  defaultEmail = "",
+}: {
+  onRegisteredAndLoggedIn: () => void;
+  onSwitchToLogin: (prefillEmail?: string) => void;
+  defaultName?: string;
+  defaultEmail?: string;
+}) {
+  const [step, setStep] = useState<"details" | "otp">("details");
+  const [name, setName] = useState(defaultName);
+  const [email, setEmail] = useState(defaultEmail);
+  const [password, setPassword] = useState("");
+  const [otp, setOtp] = useState("");
+  const [detailsState, setDetailsState] = useState<FormState>(initialFormState);
+  const [otpState, setOtpState] = useState<FormState>(initialFormState);
+  const [resendLoading, setResendLoading] = useState(false);
+
+  async function sendSignupOtp(nextEmail: string) {
+    await requestOtp({
+      email: nextEmail.trim(),
+      purpose: "sign-up",
+    });
+  }
+
+  async function handleDetailsSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setDetailsState({ loading: true, error: null, success: null });
+
+    try {
+      await sendSignupOtp(email);
+      setStep("otp");
+      setDetailsState({
+        loading: false,
+        error: null,
+        success: `OTP has been sent to ${email.trim()}.`,
+      });
+      setOtpState(initialFormState);
+    } catch (error) {
+      setDetailsState({
+        loading: false,
+        error: error instanceof Error ? error.message : "Unable to send OTP.",
+        success: null,
+      });
+    }
+  }
+
+  async function handleVerifyAndRegister(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setOtpState({ loading: true, error: null, success: null });
+
+    try {
+      await verifyOtpCode({
+        email: email.trim(),
+        otp: otp.trim(),
+        purpose: "sign-up",
+      });
+
+      await registerWithPassword({
+        email: email.trim(),
+        password,
+        name: name.trim() || undefined,
+      });
+
+      await loginWithPassword({
+        email: email.trim(),
+        password,
+      });
+
+      setOtpState({
+        loading: false,
+        error: null,
+        success: `Account created and logged in as ${email.trim()}.`,
+      });
+      onRegisteredAndLoggedIn();
+    } catch (error) {
+      setOtpState({
+        loading: false,
+        error: error instanceof Error ? error.message : "Unable to complete registration.",
+        success: null,
+      });
+    }
+  }
+
+  async function handleResend() {
+    setResendLoading(true);
+    setOtpState((current) => ({ ...current, error: null, success: null }));
+
+    try {
+      await sendSignupOtp(email);
+      setOtpState({
+        loading: false,
+        error: null,
+        success: `A new OTP has been sent to ${email.trim()}.`,
+      });
+    } catch (error) {
+      setOtpState({
+        loading: false,
+        error: error instanceof Error ? error.message : "Unable to resend OTP.",
+        success: null,
+      });
+    } finally {
+      setResendLoading(false);
+    }
+  }
+
+  if (step === "otp") {
+    return (
+      <RegisterOtpStep
+        email={email.trim()}
+        otp={otp}
+        state={otpState}
+        onOtpChange={setOtp}
+        onSubmit={handleVerifyAndRegister}
+        onBack={() => setStep("details")}
+        onResend={handleResend}
+        resendLoading={resendLoading}
+      />
+    );
+  }
+
+  return (
+    <RegisterDetailsStep
+      name={name}
+      email={email}
+      password={password}
+      state={detailsState}
+      onNameChange={setName}
+      onEmailChange={setEmail}
+      onPasswordChange={setPassword}
+      onSubmit={handleDetailsSubmit}
+      onSwitchToLogin={() => onSwitchToLogin(email.trim())}
+    />
+  );
+}

--- a/components/auth/register-otp-step.tsx
+++ b/components/auth/register-otp-step.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { KeyRound, RotateCcw } from "lucide-react";
+
+import { AuthFeedback } from "@/components/auth/auth-feedback";
+import { FormField } from "@/components/auth/form-field";
+import type { FormState } from "@/components/auth/types";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+export function RegisterOtpStep({
+  email,
+  otp,
+  state,
+  onOtpChange,
+  onSubmit,
+  onBack,
+  onResend,
+  resendLoading,
+}: {
+  email: string;
+  otp: string;
+  state: FormState;
+  onOtpChange: (value: string) => void;
+  onSubmit: (event: React.FormEvent<HTMLFormElement>) => void;
+  onBack: () => void;
+  onResend: () => void;
+  resendLoading: boolean;
+}) {
+  return (
+    <form className="space-y-4" onSubmit={onSubmit}>
+      <AuthFeedback state={state} />
+
+      <div className="rounded-lg border bg-muted/30 p-4 text-sm text-muted-foreground">
+        Mã OTP đã được gửi tới <span className="font-medium text-foreground">{email}</span>.
+        Nhập mã để hoàn tất đăng ký, sau đó hệ thống sẽ tự động đăng nhập cho bạn.
+      </div>
+
+      <FormField label="OTP code" htmlFor="register-otp-code">
+        <Input
+          id="register-otp-code"
+          type="text"
+          inputMode="numeric"
+          pattern="[0-9]{6}"
+          value={otp}
+          onChange={(event) => onOtpChange(event.target.value)}
+          placeholder="6-digit code"
+          required
+        />
+      </FormField>
+
+      <div className="flex gap-3">
+        <Button className="flex-1" type="submit" disabled={state.loading}>
+          <KeyRound className="size-4" />
+          {state.loading ? "Verifying..." : "Xác minh & tạo tài khoản"}
+        </Button>
+        <Button type="button" variant="outline" onClick={onResend} disabled={resendLoading}>
+          <RotateCcw className="size-4" />
+          {resendLoading ? "Đang gửi..." : "Gửi lại mã"}
+        </Button>
+      </div>
+
+      <div className="text-center">
+        <button
+          type="button"
+          className="text-sm font-medium text-foreground underline underline-offset-4"
+          onClick={onBack}
+        >
+          Quay lại để sửa thông tin
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/components/auth/types.ts
+++ b/components/auth/types.ts
@@ -1,0 +1,11 @@
+export interface FormState {
+  loading: boolean;
+  error: string | null;
+  success: string | null;
+}
+
+export const initialFormState: FormState = {
+  loading: false,
+  error: null,
+  success: null,
+};

--- a/lib/auth/client.ts
+++ b/lib/auth/client.ts
@@ -1,0 +1,111 @@
+export type OtpPurpose = "sign-in" | "sign-up" | "verify-email" | "reset-password" | "link-account";
+
+export interface AuthApiError {
+  ok: false;
+  error: string;
+  details?: unknown;
+}
+
+export interface AuthUser {
+  id?: string | null;
+  email: string;
+  emailVerifiedAt?: string | Date | null;
+  lastLoginAt?: string | Date | null;
+  name?: string | null;
+  avatarUrl?: string | null;
+  createdAt?: string | Date;
+  updatedAt?: string | Date;
+}
+
+export interface AuthSuccessResponse {
+  ok: true;
+  user?: AuthUser | null;
+  userId?: string;
+  message?: string;
+  purpose?: OtpPurpose;
+  expiresAt?: string | Date;
+  verified?: boolean;
+}
+
+async function parseResponse(response: Response) {
+  const payload = (await response.json().catch(() => null)) as AuthSuccessResponse | AuthApiError | null;
+
+  if (!response.ok || !payload || payload.ok === false) {
+    const message = payload && "error" in payload && payload.error ? payload.error : "Request failed";
+    throw new Error(message);
+  }
+
+  return payload;
+}
+
+export async function registerWithPassword(input: { email: string; password: string; name?: string }) {
+  const response = await fetch("/api/auth/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(input),
+  });
+
+  return parseResponse(response);
+}
+
+export async function loginWithPassword(input: { email: string; password: string }) {
+  const response = await fetch("/api/auth/login", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(input),
+  });
+
+  return parseResponse(response);
+}
+
+export async function requestOtp(input: { email: string; purpose: OtpPurpose }) {
+  const response = await fetch("/api/auth/request-otp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(input),
+  });
+
+  return parseResponse(response);
+}
+
+export async function verifyOtpCode(input: { email: string; otp: string; purpose: OtpPurpose }) {
+  const response = await fetch("/api/auth/verify-otp", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    credentials: "include",
+    body: JSON.stringify(input),
+  });
+
+  return parseResponse(response);
+}
+
+export async function fetchCurrentSession() {
+  const response = await fetch("/api/auth/me", {
+    method: "GET",
+    credentials: "include",
+    cache: "no-store",
+  });
+
+  if (!response.ok) {
+    return null;
+  }
+
+  const payload = (await response.json().catch(() => null)) as AuthSuccessResponse | null;
+  if (!payload?.ok || !payload.user) {
+    return null;
+  }
+
+  return payload;
+}
+
+export async function logoutCurrentSession() {
+  const response = await fetch("/api/auth/logout", {
+    method: "POST",
+    credentials: "include",
+  });
+
+  return parseResponse(response);
+}


### PR DESCRIPTION
## Summary

Add a dedicated `/auth` page with a minimal tabbed authentication UI wired to the existing backend auth APIs.

## Changes

- add `app/auth/page.tsx` as a dedicated auth entry page
- add `components/auth/auth-shell.tsx` with tabbed flows for login, register, request OTP, and verify OTP
- add `lib/auth/client.ts` for browser-side auth API helpers
- add a lightweight `Auth` entry button from the home page without changing the family tree flow
- show current session state using `/api/auth/me`
- support logout via `/api/auth/logout`
- include basic loading, success, and error handling for invalid credentials and OTP failures
- keep OTP purpose selection extensible, including `link-account`, without implementing social login yet

## Testing

- `pnpm build` ✅
- `pnpm lint` ⚠️ fails in this environment because `eslint` is not installed (`sh: 1: eslint: not found`)

Closes #28